### PR TITLE
Fix data mask alignment in LSU

### DIFF
--- a/v/src/MSHR.scala
+++ b/v/src/MSHR.scala
@@ -237,7 +237,7 @@ class MSHR(param: MSHRParam) extends Module {
   tlPort.d.ready := vrfWritePort.ready
   vrfWritePort.bits.vd := requestReg.instInf.vs3 + Mux(segType, tlPort.d.bits.sink(2, 0), baseByteOffset(14, 12))
   vrfWritePort.bits.offset := elementIndex(11, 5)
-  vrfWritePort.bits.data := tlPort.d.bits.data
+  vrfWritePort.bits.data := (tlPort.d.bits.data << (baseByteOffset(1, 0) ## 0.U(3.W))).asUInt
   vrfWritePort.bits.last := last
   vrfWritePort.bits.instIndex := requestReg.instIndex
   vrfWritePort.bits.mask := Mux1H(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44799832/199880979-dbd3d7a1-4616-40a0-ab70-087ef55742bb.png)
数据和mask没有对齐：在mask为0b0100的时候数据有效位在最低位，应该是0x570000