### PR TITLE
fix wrong calculation of target lane

### DIFF
--- a/v/src/LSU.scala
+++ b/v/src/LSU.scala
@@ -152,7 +152,7 @@ class LSU(param: LSUParam) extends Module {
     writeQueueVec(index).io.enq.bits.data := mshr.vrfWritePort.bits
     writeQueueVec(index).io.enq.bits.targetLane := mshr.status.targetLane
     mshr.vrfWritePort.ready := writeQueueVec(index).io.enq.ready
-    tryToWriteData(index) := Mux(writeQueueVec(index).io.deq.valid, writeQueueVec(index).io.enq.bits.targetLane, 0.U)
+    tryToWriteData(index) := Mux(writeQueueVec(index).io.deq.valid, writeQueueVec(index).io.deq.bits.targetLane, 0.U)
     writeQueueVec(index).io.deq.ready := getWritePort(index)
 
     mshr.csrInterface := csrInterface


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44799832/199886294-74bfdeeb-4dad-4b97-8282-c1c60155fbd8.png)
前四个ld的element写的目标应该都是lane0的，然而第四个写到lane1去了