### PR TITLE
fix execute result and instruction misalignment

### DIFF
--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -758,6 +758,7 @@ class Lane(param: LaneParameters) extends Module {
     controlValid := VecInit(controlValid.tail :+ validRegulate)
     source1 := VecInit(source1.tail :+ vs1entrance)
     control := VecInit(control.tail :+ entranceControl)
+    result := VecInit(result.tail :+ 0.U(param.ELEN.W))
     vrf.instWriteReport.valid := true.B
   }
   vrf.flush := DontCare


### PR DESCRIPTION
![4](https://user-images.githubusercontent.com/44799832/199891525-8026c195-b77c-46c4-9391-543752c849b7.png)
在图中的最后，在02的位置写了一次rf，然后看到上面的controlValid的变化可以知道在上一个周期指令的控制逻辑经过了一次移位，但是执行结果并没有跟过来，解决方案暂时有两种：
1. 结果也跟过来
2. 改控制，在某些阶段里不让移动

这里用的是第一种方案，因为能及时移动让新指令进来，预计付出的代价也不比第二种方案大