### PR TITLE
[cosim] check vrf write after commit

### DIFF
--- a/tests/emulator/src/spike_event.cc
+++ b/tests/emulator/src/spike_event.cc
@@ -152,10 +152,6 @@ void SpikeEvent::check_is_ready_for_commit() {
                                 addr, describe_insn());
     }
   }
-  for (auto &[idx, vrf_write]: vrf_access_record.all_writes) {
-    CHECK_S(vrf_write.executed) << fmt::format("expect to write vrf {}, not executed when commit ({})",
-                              idx, describe_insn());
-  }
 }
 
 void SpikeEvent::record_rd_write(VV &top) {
@@ -164,4 +160,8 @@ void SpikeEvent::record_rd_write(VV &top) {
     CHECK_EQ_S(top.resp_bits_data, rd_bits) << fmt::format(": expect to write rd[{}] = {}, actual {}",
                                                              rd_idx, rd_bits, top.resp_bits_data);
   }
+}
+
+bool SpikeEvent::is_vrf_write_done() {
+  return vrf_access_record.executed_writes == vrf_access_record.all_writes.size();
 }

--- a/tests/emulator/src/spike_event.h
+++ b/tests/emulator/src/spike_event.h
@@ -41,7 +41,6 @@ struct SpikeEvent {
   VBridgeImpl *impl;
 
   bool is_issued;
-  bool is_committed;
 
   bool is_load;
   bool is_store;
@@ -75,6 +74,11 @@ struct SpikeEvent {
   bool _ignore_exception = false;  // TODO: give it correct value
   bool _store_buffer_clear = false;  // TODO: give it correct value
 
+  /// since rtl may continue write vrf even after it is committed, we need keeping recording vrf write
+  /// after committing, and check if all vrf is written when cycles_after_commit hits a given threshold
+  bool is_committed;
+  uint64_t commit_time_point;
+
   struct vd_write_record_t {
     std::unique_ptr<uint8_t[]> vd_bytes;
   } vd_write_record;
@@ -104,8 +108,10 @@ struct SpikeEvent {
     };
     // maps (vlen * bytes_per_vrf + byte_offset) to single_vrf_write
     std::map<uint32_t, single_vrf_write> all_writes;
+    int executed_writes = 0;
   } vrf_access_record;
 
   void record_rd_write(VV &top);
   void check_is_ready_for_commit();
+  bool is_vrf_write_done();
 };

--- a/tests/emulator/src/vbridge_config.h
+++ b/tests/emulator/src/vbridge_config.h
@@ -16,4 +16,6 @@ constexpr int numTL = 2;
 constexpr int numMSHR = 3;
 constexpr int numLanes = 8;
 
+constexpr uint64_t check_threshold_after_commit = 1028;
+
 }

--- a/tests/emulator/src/vbridge_impl.h
+++ b/tests/emulator/src/vbridge_impl.h
@@ -60,7 +60,7 @@ private:
   /// record the behavior of this instruction, and send to str_stack.
   /// in the RTL thread, the RTL driver will consume from this queue, drive signal based on the queue.
   /// size of this queue should be as big as enough to make rtl free to run, reducing the context switch overhead.
-  std::list<SpikeEvent> to_rtl_queue;
+  std::deque<SpikeEvent> to_rtl_queue;
 
   // in vrf_shadow we keep a duplicate of vrf in rtl, in order to detect unexpected vrf write
   std::unique_ptr<uint8_t[]> vrf_shadow;
@@ -97,6 +97,7 @@ private:
   void record_rf_accesses();
   void return_tl_response();
   void receive_tl_req();
+  void check_se_post_commit();
 
   int get_mem_req_cycles() {
     return 1;


### PR DESCRIPTION
Because rtl may continue write vrf even after committed, it is
necessary to delay the vrf-all-write check a while after commit.
