### PR TITLE
[build system] fix build system cache issue

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -144,15 +144,15 @@ object tests extends Module {
     }
 
     def elaborate = T {
-      mill.modules.Jvm.runSubprocess(
+      // class path for `moduleDeps` is only a directory, not a jar, which breaks the cache.
+      // so we need to manually add the class files of `moduleDeps` here.
+      upstreamCompileOutput()
+      mill.modules.Jvm.runLocal(
         finalMainClass(),
         runClasspath().map(_.path),
-        Seq.empty,
-        Map.empty,
         Seq(
           "--dir", T.dest.toString,
         ),
-        workingDir = T.dest
       )
       PathRef(T.dest)
     }


### PR DESCRIPTION
if RTL is changed(from vector compile unit), it will result the same
classpath in elaborate, since the input of elaborate is runClasspath(the
path of classpath directory), it doesn't consume the zinc analysis file.
In the commit, I add upstreamCompileOuput to elaborate dependency, which
pulls all zinc analysis result to this JVM run.
