### PR TITLE
[cosim] fix uncleared log, overwritten record

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
         ];
       in
         {
+          legacyPackages = pkgs;
           devShell = pkgs.mkShell.override { stdenv = pkgs.myLLVM.stdenv; } {
             buildInputs = deps;
           };

--- a/tests/emulator/src/spike_event.cc
+++ b/tests/emulator/src/spike_event.cc
@@ -1,8 +1,9 @@
 #include <fmt/core.h>
 #include <glog/logging.h>
 
-#include "spike_event.h"
 #include "disasm.h"
+
+#include "spike_event.h"
 #include "util.h"
 #include "tl_interface.h"
 #include "exceptions.h"
@@ -78,10 +79,6 @@ void SpikeEvent::log_arch_changes() {
     LOG(INFO) << fmt::format("spike detect mem read {:08X} on {:08X} with size={}byte", value, address, size_by_byte);
     mem_access_record.all_reads[address] = { .size_by_byte = size_by_byte, .val = value };
   }
-
-  state->log_reg_write.clear();
-  state->log_mem_read.clear();
-  state->log_mem_write.clear();
 }
 
 SpikeEvent::SpikeEvent(processor_t &proc, insn_fetch_t &fetch, VBridgeImpl *impl): proc(proc), impl(impl) {

--- a/tests/emulator/src/spike_event.h
+++ b/tests/emulator/src/spike_event.h
@@ -15,6 +15,13 @@
 
 class VBridgeImpl;
 
+inline void clear_state(processor_t &proc) {
+  auto *state = proc.get_state();
+  state->log_reg_write.clear();
+  state->log_mem_read.clear();
+  state->log_mem_write.clear();
+}
+
 struct SpikeEvent {
   SpikeEvent(processor_t &proc, insn_fetch_t &fetch, VBridgeImpl *impl);
 

--- a/tests/emulator/src/util.h
+++ b/tests/emulator/src/util.h
@@ -35,3 +35,19 @@ erase_if( std::map<Key,T,Compare,Alloc>& c, Pred pred ) {
   }
   return old_size - c.size();
 };
+
+/// back-port of `std::erase_if` in C++ 20.
+/// refer to https://en.cppreference.com/w/cpp/container/map/erase_if
+template< class Key, class T, class Compare, class Alloc, class Pred >
+typename std::multimap<Key,T,Compare,Alloc>::size_type
+erase_if( std::multimap<Key,T,Compare,Alloc>& c, Pred pred ) {
+  auto old_size = c.size();
+  for (auto i = c.begin(), last = c.end(); i != last; ) {
+    if (pred(*i)) {
+      i = c.erase(i);
+    } else {
+      ++i;
+    }
+  }
+  return old_size - c.size();
+};

--- a/tests/emulator/src/vbridge_impl.h
+++ b/tests/emulator/src/vbridge_impl.h
@@ -55,7 +55,7 @@ private:
   isa_parser_t isa;
   processor_t proc;
   uint64_t _cycles;
-  std::map<reg_t, TLReqRecord> tl_banks[consts::numTL];
+  std::multimap<reg_t, TLReqRecord> tl_banks[consts::numTL];
 
   /// to rtl stack
   /// in the spike thread, spike should detech if this queue is full, if not full, execute until a vector instruction,


### PR DESCRIPTION
1. previously we use std::map to record spike mem record indexed by
   addr, but it causes record with the same addr being overwritten.
2. previously for non-vector instructions, spike log record is not
   recorded before execution, causing the log containing accesses from
   previous non-vector instructions.
