### PR TITLE
Handling st instructions

### DIFF
--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -852,7 +852,7 @@ class Lane(param: LaneParameters) extends Module {
   ).asUInt.andR
   val validRegulate: Bool = laneReq.valid && typeReady
   laneReq.ready := !controlValid.head && typeReady && vrf.instWriteReport.ready
-  vrf.instWriteReport.valid := laneReq.fire
+  vrf.instWriteReport.valid := laneReq.fire && !entranceControl.instCompleted
   when(!controlValid.head && (controlValid.asUInt.orR || validRegulate)) {
     controlValid := VecInit(controlValid.tail :+ validRegulate)
     source1 := VecInit(source1.tail :+ vs1entrance)

--- a/v/src/MSHR.scala
+++ b/v/src/MSHR.scala
@@ -129,7 +129,7 @@ class MSHR(param: MSHRParam) extends Module {
   val putData:     UInt = Wire(UInt(param.ELEN.W))
   val segAddressMul: UInt = (requestReg.instInf.nf + 1.U) * (1.U << dataEEW).asUInt(2, 0)
   val reqAddress: UInt = requestReg.rs1Data + reqOffset * segAddressMul  + segmentOffset
-  val reqMask:    UInt = dataEEWOH(2) ## dataEEWOH(2) ## (dataEEWOH(2) || dataEEWOH(1)) ## true.B
+  val reqMask:    UInt = Wire(UInt(param.dataBits.W))
 
   tlPort.a.bits.opcode := !requestReg.instInf.st ## 0.U(2.W)
   tlPort.a.bits.param := 0.U
@@ -255,6 +255,7 @@ class MSHR(param: MSHRParam) extends Module {
       15.U(4.W)
     )
   )
+  reqMask := vrfWritePort.bits.mask
 
   val sourceUpdate: UInt = Mux(tlPort.a.fire, reqSource1H, 0.U(param.lsuGroupLength.W))
   val respSourceUpdate: UInt = Mux(tlPort.d.fire, respSourceOH, 0.U(param.lsuGroupLength.W))

--- a/v/src/MSHR.scala
+++ b/v/src/MSHR.scala
@@ -302,7 +302,7 @@ class MSHR(param: MSHRParam) extends Module {
   status.waitFirstResp := waitFirstResp
   maskSelect.bits := groupIndex
   putData := readResult
-  readDataPort.valid := stateReady
+  readDataPort.valid := stateReady && requestReg.instInf.st
   readDataPort.bits.offset := vrfWritePort.bits.offset
   readDataPort.bits.vs := vrfWritePort.bits.vd
   readDataPort.bits.instIndex := requestReg.instIndex


### PR DESCRIPTION
- [rtl] Address calculation for accessing vrf when executing st instruction.
- [rtl] load instruction does not need to read the vrf.
- [rtl] Do not record instruction that end on the spot in vrf.
- [rtl] ix the issue that put's mask is not aligned.
