### PR TITLE
vaadd debug

### DIFF
--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -368,13 +368,13 @@ class Lane(param: LaneParameters) extends Module {
       // vs2 read
       vrfReadWire(index)(1).valid := !record.state.sRead2 && controlActive(index)
       vrfReadWire(index)(1).bits.offset := Mux(needCrossRead, record.counter(param.offsetBits - 2, 0) ## false.B, record.counter(param.offsetBits - 1, 0))
-      vrfReadWire(index)(1).bits.vs := record.originalInformation.vs2 + Mux(needCrossRead, record.counter(param.groupSizeBits - 1, param.offsetBits - 1) ## false.B, record.counter(param.groupSizeBits - 1, param.offsetBits - 1))
+      vrfReadWire(index)(1).bits.vs := record.originalInformation.vs2 + Mux(needCrossRead, record.counter(param.groupSizeBits - 1, param.offsetBits - 1) ## false.B, record.counter(param.groupSizeBits - 1, param.offsetBits))
       vrfReadWire(index)(1).bits.instIndex := record.originalInformation.instIndex
 
       // vd read
       vrfReadWire(index)(2).valid := !record.state.sReadVD && controlActive(index)
       vrfReadWire(index)(2).bits.offset := Mux(needCrossRead, record.counter(param.offsetBits - 2, 0) ## true.B, record.counter(param.offsetBits - 1, 0))
-      vrfReadWire(index)(2).bits.vs := record.originalInformation.vd + Mux(needCrossRead, record.counter(param.groupSizeBits - 1, param.offsetBits - 1) ## true.B, record.counter(param.groupSizeBits - 1, param.offsetBits - 1))
+      vrfReadWire(index)(2).bits.vs := record.originalInformation.vd + Mux(needCrossRead, record.counter(param.groupSizeBits - 1, param.offsetBits - 1) ## true.B, record.counter(param.groupSizeBits - 1, param.offsetBits))
       vrfReadWire(index)(2).bits.instIndex := record.originalInformation.instIndex
 
       val readFinish =

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -668,7 +668,7 @@ class Lane(param: LaneParameters) extends Module {
         }.otherwise {
           record.state := record.initState
           record.counter := nextGroupCount
-          record.executeIndex := 0.U
+          record.executeIndex := nextExecuteIndex
           record.vrfWriteMask := 0.U
         }
       }

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -112,7 +112,7 @@ class V(param: VParam) extends Module {
         .grouped(param.lane).toSeq.transpose.map(seq => VecInit(seq).asUInt)
     }.transpose.map(VecInit(_).asUInt)
   }.transpose.map(Mux1H(sew1H(2, 0), _)).map {v0ForLane =>
-    VecInit(v0ForLane.asBools.grouped(8).toSeq.map(VecInit(_).asUInt))
+    VecInit(v0ForLane.asBools.grouped(32).toSeq.map(VecInit(_).asUInt))
   }
 
   val instEnq:    UInt = Wire(UInt(param.chainingSize.W))


### PR DESCRIPTION
- [rtl] Fix the issue of v0 grouping.
- [rtl] When the group changes, the mask type instruction needs to update executeIndex.
- [rtl] ExecuteIndex is used incorrectly when vsew=1.
- [rtl] The register increment for reading source is miscalculated.
