### PR TITLE
vwadd debug

### DIFF
--- a/tests/passed.txt
+++ b/tests/passed.txt
@@ -22,3 +22,4 @@ vsll_vx
 vxor_vi
 vxor_vv
 vxor_vx
+vwadd_vv

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -226,6 +226,7 @@ class WriteBusData(param: LaneParameters) extends Bundle {
   // todo: for debug
   val from:    UInt = UInt(param.laneIndexBits.W)
   val instIndex: UInt = UInt(param.instIndexSize.W)
+  val counter: UInt = UInt(param.groupSizeBits.W)
 }
 
 class RingPort[T <: Data](gen: T) extends Bundle {
@@ -434,6 +435,7 @@ class Lane(param: LaneParameters) extends Module {
         sendWriteData.bits.from := laneIndex
         sendWriteData.bits.tail := laneIndex(param.laneIndexBits - 1)
         sendWriteData.bits.instIndex := record.originalInformation.instIndex
+        sendWriteData.bits.counter := record.counter
         sendWriteData.bits.data := Mux(sendWriteHead, crossWriteResultHead, crossWriteResultTail)
         sendWriteData.bits.mask := Mux(sendWriteHead, crossWriteMaskHead, crossWriteMaskTail)
         sendWriteData.valid := sendWriteHead || sendWriteTail
@@ -804,7 +806,7 @@ class Lane(param: LaneParameters) extends Module {
     writeBusPort.enq.ready := true.B
     writeBusDataReg.valid := false.B
     crossWriteQueue.io.enq.bits.vd := control.head.originalInformation.vd
-    crossWriteQueue.io.enq.bits.offset := control.head.originalInformation.instIndex ## writeBusPort.enq.bits.tail
+    crossWriteQueue.io.enq.bits.offset := writeBusPort.enq.bits.counter ## writeBusPort.enq.bits.tail
     crossWriteQueue.io.enq.bits.data := writeBusPort.enq.bits.data
     crossWriteQueue.io.enq.bits.last := instWillComplete.head && writeBusPort.enq.bits.tail
     crossWriteQueue.io.enq.bits.instIndex := control.head.originalInformation.instIndex

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -809,7 +809,7 @@ class Lane(param: LaneParameters) extends Module {
     val writeBusIndexMatch = writeBusPort.enq.bits.target === laneIndex && crossWriteQueue.io.enq.ready
     writeBusPort.enq.ready := true.B
     writeBusDataReg.valid := false.B
-    crossWriteQueue.io.enq.bits.vd := control.head.originalInformation.vd
+    crossWriteQueue.io.enq.bits.vd := control.head.originalInformation.vd + writeBusPort.enq.bits.counter(3, 1)
     crossWriteQueue.io.enq.bits.offset := writeBusPort.enq.bits.counter ## writeBusPort.enq.bits.tail
     crossWriteQueue.io.enq.bits.data := writeBusPort.enq.bits.data
     crossWriteQueue.io.enq.bits.last := instWillComplete.head && writeBusPort.enq.bits.tail

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -533,6 +533,10 @@ class Lane(param: LaneParameters) extends Module {
           }
 
         }
+        when(record.state.asUInt.andR) {
+          crossWriteMaskHead := 0.U
+          crossWriteMaskTail := 0.U
+        }
       }
       // 发起执行单元的请求
       /** 计算结果需要偏移的: executeIndex * 8 */


### PR DESCRIPTION
- [rtl] Instruction commit requires waiting for bus clear
- [rtl] Handling W-type instructions with masks
- [rtl] Correctly calculate the offset when w-type instruction write vrf
- [rtl] Clean up the residual mask when changing groups.
- [rtl] Handling cross-register writes for w-type instruction.
