### PR TITLE
[cosim] enlarge memory capacity to avoid spike crash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             libargs
             glog
             fmt
-            libspike
+            (enableDebugging libspike)
             zlib
 
             mill

--- a/tests/emulator/src/dpi.cc
+++ b/tests/emulator/src/dpi.cc
@@ -195,7 +195,6 @@ void VBridgeImpl::dpiDumpWave() {
 })
 
 [[maybe_unused]] void dpiChainingMonitor(int lane_idx, const svBitVecVal *slot_occupied) TRY({
-  LOG(INFO) << fmt::format("occupied: {:08b}", *slot_occupied);
   chaining_perf.step(lane_idx, slot_occupied);
 })
 

--- a/tests/emulator/src/simple_sim.h
+++ b/tests/emulator/src/simple_sim.h
@@ -10,9 +10,10 @@
 class simple_sim : public simif_t {
 private:
   char *mem;
+  size_t mem_size;
 
 public:
-  explicit simple_sim(size_t mem_size) {
+  explicit simple_sim(size_t mem_size): mem_size(mem_size) {
     mem = new char[mem_size];
   }
 
@@ -33,6 +34,7 @@ public:
 
   // should return NULL for MMIO addresses
   char *addr_to_mem(reg_t addr) override {
+    CHECK_S(addr < mem_size) << fmt::format("memory out of bound ({} >= {})", addr, mem_size);
     return &mem[addr];
   }
 

--- a/tests/emulator/src/vbridge_impl.cc
+++ b/tests/emulator/src/vbridge_impl.cc
@@ -159,7 +159,7 @@ void VBridgeImpl::dpiPeekWriteQueue(const VLsuWriteQueuePeek &lsu_queue) {
 }
 
 VBridgeImpl::VBridgeImpl() :
-    sim(1 << 30),
+    sim(1l << 32),
     isa("rv32gcv", "M"),
     proc(
         /*isa*/ &isa,
@@ -203,6 +203,7 @@ std::optional<SpikeEvent> VBridgeImpl::spike_step() {
     pc = fetch.func(&proc, fetch.insn, state->pc);
     se.log_arch_changes();
   } else {
+    VLOG(1) << fmt::format("spike run {} (pc={})", proc.get_disassembler()->disassemble(fetch.insn), pc);
     pc = fetch.func(&proc, fetch.insn, state->pc);
   }
 


### PR DESCRIPTION
when allocating 1GB memory, spike jumps to mysterious instructions and crash suprisingly, enlarging to 4GB seems to make things work.

Some additional debugging logging and assertions are also added in this commit.
