### PR TITLE
index debug

### DIFF
--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -1437,15 +1437,17 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
         val noNeedWaitScheduler: Bool = !(canSendMaskRequest && !record.initState.sScheduler) || schedulerFinish
         // 往外边发的是原始的数据
         maskRequest.data := Mux(
-          record.originalInformation.decodeResult(Decoder.maskDestination),
+          // todo: decode
+          record.originalInformation.decodeResult(Decoder.maskDestination) && !record.originalInformation.loadStore,
           maskFormatResult,
           Mux(
             updateReduce,
             reduceResult(index),
             Mux(
-              record.originalInformation.decodeResult(Decoder.gather),
+              record.originalInformation.decodeResult(Decoder.gather) && !record.originalInformation.loadStore,
               source1(index),
-              Mux(record.originalInformation.decodeResult(Decoder.ffo), ffoIndexReg, source2(index))
+              Mux(record.originalInformation.decodeResult(Decoder.ffo) && !record.originalInformation.loadStore,
+                ffoIndexReg, source2(index))
             )
 
           )

--- a/v/src/MSHR.scala
+++ b/v/src/MSHR.scala
@@ -241,7 +241,7 @@ class MSHR(param: MSHRParam) extends Module {
     val nextIndexReq: Bool = indexType && indexLaneMask(7) && indexExhausted
     // 既然试图请求新的index,那说明前一组全用完了
     Seq.tabulate(param.lane) {
-      i => offsetUsed(i) := (segExhausted && indexLaneMask(i) && indexExhausted) || status.indexGroupEnd
+      i => offsetUsed(i) := (segExhausted && indexLaneMask(i) && indexExhausted) || status.indexGroupEnd || maskNeedUpdate
     }
   }
   val groupEnd: Bool = maskNeedUpdate || (reqNext(param.maskGroupWidth - 1) && tlPort.a.fire && lastElementForSeg)


### PR DESCRIPTION
- [rtl] Index must have been used up when mask changed groups.
- [rtl] Select the correct data as index in lane.
