### PR TITLE
index debug

### DIFF
--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -119,7 +119,7 @@ class LaneRequest(param: LaneParameter) extends Bundle {
     res.wExecuteRes := (special && !decodeResult(Decoder.ffo)) || readOnly || decodeResult(Decoder.nr)
     res.sWrite := (decodeResult(Decoder.other) && decodeResult(Decoder.targetRd)) || readOnly ||
       decodeResult(Decoder.widen) || decodeResult(Decoder.maskDestination) ||
-      decodeResult(Decoder.red) || decodeResult(Decoder.popCount)
+      decodeResult(Decoder.red) || decodeResult(Decoder.popCount) || loadStore
     res.sCrossWrite0 := !crossWrite
     res.sCrossWrite1 := !crossWrite
     res.sSendResult0 := !crossRead

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -114,7 +114,7 @@ class LaneRequest(param: LaneParameter) extends Bundle {
     // todo
     res.sScheduler := !(decodeResult(Decoder.maskDestination) || decodeResult(Decoder.red) || readOnly
       || decodeResult(Decoder.ffo) || decodeResult(Decoder.popCount) || loadStore)
-    res.sExecute := readOnly || decodeResult(Decoder.nr)
+    res.sExecute := readOnly || decodeResult(Decoder.nr) || loadStore
     //todo: red
     res.wExecuteRes := (special && !decodeResult(Decoder.ffo)) || readOnly || decodeResult(Decoder.nr)
     res.sWrite := (decodeResult(Decoder.other) && decodeResult(Decoder.targetRd)) || readOnly ||

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -1763,7 +1763,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   entranceControl.schedulerComplete := false.B
   entranceControl.selfCompleted := false.B
   entranceControl.instCompleted := (((laneIndex ## 0.U(2.W)) >> csrInterface.vSew).asUInt >= csrInterface.vl ||
-    maskLogicCompleted) && !laneRequest.bits.decodeResult(Decoder.nr)
+    maskLogicCompleted) && !laneRequest.bits.decodeResult(Decoder.nr) && !laneRequest.bits.loadStore
   entranceControl.mask.valid := laneRequest.bits.mask
   entranceControl.mask.bits := maskInput
   entranceControl.maskGroupedOrR := maskGroupedOrR

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -1791,7 +1791,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
     instructionTypeVec.zip(slotOccupied).map { case (t, v) => (t =/= entranceInstType) || !v }
   ).asUInt.andR
   val validRegulate: Bool = laneRequest.valid && typeReady
-  val shiftReady = slotCanShift.asUInt.andR
+  val shiftReady = slotCanShift.asUInt.andR && !laneResponseFeedback.valid
   laneRequest.ready := !slotOccupied.head && typeReady && vrf.instWriteReport.ready && shiftReady
   vrf.instWriteReport.valid := (laneRequest.fire || (!laneRequest.bits.store && laneRequest.bits.loadStore)) && !entranceControl.instCompleted
   when(!slotOccupied.head && (slotOccupied.asUInt.orR || validRegulate) && shiftReady) {

--- a/v/src/MSHR.scala
+++ b/v/src/MSHR.scala
@@ -404,8 +404,8 @@ class MSHR(param: MSHRParam) extends Module {
       state := wResp
     }
   }
-
-  when(state === wResp && respFinish && slotClear) {
+  // todo: cosim 有时会在resp done的时候继续发曾经回过的回应,但是newGroup会导致vrf寻址错误,先 && !tlPort.d.valid 绕一下
+  when(state === wResp && respFinish && slotClear && !tlPort.d.valid) {
     when(last) {
       state := idle
     }.otherwise {


### PR DESCRIPTION
- [rtl] Adjust the timing of updating the group.
- [rtl] The ls type instruction should not be terminated by itself in lane.
- [rtl] No shift when there is feedback to prevent loss of information.
- [rtl] Do not actively write vrf for ls-type instruction.
- [rtl] ls_type instruction also does not need to be executed.
