### PR TITLE
fix intrinsic cases (#218)

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -177,7 +177,6 @@ object tests extends Module {
       os.proc("firtool",
         elaborate.chirrtl().path,
         s"--annotation-file=${elaborate.chiselAnno().path}",
-        "-disable-infer-rw",
         "-dedup",
         "-O=debug",
         "--split-verilog",

--- a/build.sc
+++ b/build.sc
@@ -333,7 +333,7 @@ object tests extends Module {
       }
 
       def linkOpts = T {
-        Seq("-mno-relax")
+        Seq("-mno-relax", "-fno-PIC")
       }
 
       def elf: T[PathRef] = T {
@@ -374,7 +374,7 @@ object tests extends Module {
         }
 
         override def linkOpts = T {
-          Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib")
+          Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-fno-PIC")
         }
 
         override def allSourceFiles: T[Seq[PathRef]] = T {
@@ -397,7 +397,7 @@ object tests extends Module {
       override def millSourcePath = super.millSourcePath / os.up
 
       override def linkOpts = T {
-        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start")
+        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start", "-fno-PIC")
       }
 
       override def allSourceFiles: T[Seq[PathRef]] = T {
@@ -446,7 +446,7 @@ object tests extends Module {
       override def millSourcePath = super.millSourcePath / os.up
 
       override def linkOpts = T {
-        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start")
+        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start", "-fno-PIC")
       }
 
       override def allSourceFiles: T[Seq[PathRef]] = T {
@@ -462,15 +462,16 @@ object tests extends Module {
 
     class IntrinsicCase(intrinsicSourceName: String) extends Case {
       def intrinsicFile = T.source(PathRef(millSourcePath / intrinsicSourceName))
+      def mainAsmFile = T.source(PathRef(millSourcePath / "main.S"))
 
       override def millSourcePath = super.millSourcePath / os.up
 
       override def linkOpts = T {
-        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start")
+        Seq("-mno-relax", "-static", "-mcmodel=medany", "-fvisibility=hidden", "-nostdlib", "-Wl,--entry=start", "-fno-PIC")
       }
 
       override def allSourceFiles: T[Seq[PathRef]] = T {
-        Seq(PathRef(intrinsicFile().path), PathRef(millSourcePath / "main.S"))
+        Seq(PathRef(intrinsicFile().path), PathRef(mainAsmFile().path))
       }
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675785031,
-        "narHash": "sha256-M6ftknTdm/cUI3/QT7IruFTutQesf07rOtedzPclf+Q=",
+        "lastModified": 1682268651,
+        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec1e46d85ac9367d60ef6b9bdca667ae4fff76d7",
+        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "vector";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/tests/cases/intrinsic/main.S
+++ b/tests/cases/intrinsic/main.S
@@ -11,6 +11,6 @@ start:
 
     .p2align 2
 stack_start:
-    .zero 128
+    .zero 0x10000
 
 stack_end:

--- a/tests/emulator/src/elf.cc
+++ b/tests/emulator/src/elf.cc
@@ -19,7 +19,8 @@ simple_sim::load_elf_result_t simple_sim::load_elf(const std::string &fname) {
       if (phdr.p_type == PT_LOAD) {
         CHECK_S(phdr.p_paddr + phdr.p_filesz < mem_size);
         fs.seekg((long) phdr.p_offset).read(reinterpret_cast<char *>(&mem[phdr.p_paddr]), phdr.p_filesz);
-        VLOG(1) << fmt::format("load elf segment {} at file phdr_offset {:08X} to paddr {:08X}", i, phdr.p_offset, phdr.p_paddr);
+        VLOG(1) << fmt::format("load elf segment {} at file phdr_offset {:08X} to paddr {:08X}-{:08X}",
+                   i, phdr.p_offset, phdr.p_paddr, phdr.p_paddr + phdr.p_memsz);
       }
     }
     return { .entry_addr = ehdr.e_entry };


### PR DESCRIPTION
- [build system] bump nixpkgs, remove circt unused option
- [cosim] fix intrinsic cases
    1. Nix cc wrapper add `-fPIC` flag by default, causing `sp` pointing at a wrong address.
    2. Treat `main.S` as source in build.sc.
    3. Enlarge stack space for intrinsic cases.
