### PR TITLE
[test] add vector.print and @printMemref* support

### DIFF
--- a/tests/cases/buddy/main.S
+++ b/tests/cases/buddy/main.S
@@ -14,3 +14,38 @@ stack_start:
     .zero 128
 
 stack_end:
+
+# Add some print functions' definitions here
+# to support direct lowering of such func.call and vector.print 
+printMemrefI32:
+    ret
+printMemrefI64:
+    ret
+printMemrefF32:
+    ret
+printMemrefF64:
+    ret
+printMemrefInd:
+    ret
+printMemrefC32:
+    ret
+printMemrefC64:
+    ret
+printCString:
+    ret
+printI64:
+    ret
+printU64:
+    ret
+printF32:
+    ret
+printF64:
+    ret
+printOpen:
+    ret
+printClose:
+    ret
+printComma:
+    ret
+printNewline:
+    ret


### PR DESCRIPTION
Currently there is some print function to help debug in MLIR, such as `func.call @printMemrefI32` and `vector.print`. They will be lowering into function calls with specified name. This PR add empty definitions of these functions so most of our examples in Buddy-MLIR can directly lower to assembly with function calls and run on this repo. 