### PR TITLE
[buddy] Use llvm-lit like test case runner

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -404,8 +404,8 @@ object tests extends Module {
       // These arguments must be wrapped in a block, starting with "BUDDY-OPT" and ending with "BUDDY-OPT-END".
       def parseBuddyOptArg(testFile: os.Path) = os.read
             .lines(testFile)
-            .dropWhile(_ == "// BUDDY-OPT")
-            .takeWhile(_ != "// BUDDY-OPT-END")
+            .dropWhile(bound => bound.startsWith("//") && bound.contains("BUDDY-OPT"))
+            .takeWhile(bound => bound.startsWith("//") && !bound.contains("BUDDY-OPT-END"))
             .map(lines => lines.stripPrefix("//").trim().split(" "))
             .flatten
 

--- a/tests/cases/buddy/conv.mlir
+++ b/tests/cases/buddy/conv.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
   memref.global "private" @gv_i32 : memref<10x10xi32>
 
   func.func @test() -> i32 {

--- a/tests/cases/buddy/hello.mlir
+++ b/tests/cases/buddy/hello.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 memref.global "private" @gv_i32 : memref<20xi32> = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                                                           10, 11, 12, 13, 14, 15, 16, 17, 18, 19]>
 func.func @test() -> i32 {

--- a/tests/cases/buddy/matmul.mlir
+++ b/tests/cases/buddy/matmul.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 // matmul.mlir
 // Matrix multiplication with strip mining method.
 

--- a/tests/cases/buddy/maxvl-tail-setvl-front.mlir
+++ b/tests/cases/buddy/maxvl-tail-setvl-front.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 memref.global "private" @input_A : memref<1500xi32>
 memref.global "private" @input_B : memref<1500xi32>
 memref.global "private" @output : memref<1500xi32>

--- a/tests/cases/buddy/rvv-vp-intrinsic-add-scalable.mlir
+++ b/tests/cases/buddy/rvv-vp-intrinsic-add-scalable.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 // This implementation is based on [this file](https://github.com/buddy-compiler/buddy-mlir/blob/main/examples/RVVExperiment/rvv-vp-intrinsic-add-scalable.mlir) from buddy-mlir.
 
 memref.global "private" @gv_i32 : memref<20xi32> = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/tests/cases/buddy/rvv-vp-intrinsic-add.mlir
+++ b/tests/cases/buddy/rvv-vp-intrinsic-add.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 // This implementation is based on [this file](https://github.com/buddy-compiler/buddy-mlir/blob/main/examples/RVVExperiment/rvv-vp-intrinsic-add.mlir) from buddy-mlir.
 
 memref.global "private" @gv_i32 : memref<20xi32> = dense<[0, 1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/tests/cases/buddy/stripmining-huge.mlir
+++ b/tests/cases/buddy/stripmining-huge.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 memref.global "private" @gv_i32 : memref<32768xi32>
 
 func.func @test() -> i32 {

--- a/tests/cases/buddy/stripmining.mlir
+++ b/tests/cases/buddy/stripmining.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 // Copied from https://github.com/xlinsist/buddy-mlir/blob/8b7ad2a79d05273e0e398dab7ae6c309fc60c811/examples/RVVDialect/test-i32-rvv-intr.mlir
 
 module {

--- a/tests/cases/buddy/vectoradd.mlir
+++ b/tests/cases/buddy/vectoradd.mlir
@@ -1,3 +1,11 @@
+// BUDDY-OPT
+// --lower-affine --convert-scf-to-cf --convert-math-to-llvm
+// --lower-vector-exp --lower-rvv=rv32
+// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-arith-to-llvm --convert-func-to-llvm
+// --reconcile-unrealized-casts
+// BUDDY-OPT-END
+
 memref.global "private" @gv_i32 : memref<32768xi32>
 
 func.func @test() -> i32 {


### PR DESCRIPTION
Different test cases require different lowering passes, and the original implementation hard-coded all passes for all cases, which limited extensibility.

This commit adds a comment parser for mill to parse the header comment of each mlir test case to get case-specific buddy-opt argument. After this commit, developers can place passes into a block starting with keyword "BUDDY-OPT" and ending with keyword "BUDDY-OPT-END".

Here is an example for passing "--lower-rvv=rv32" to buddy-opt.

```mlir
// BUDDY-OPT
// --lower-rvv=rv32
// BUDDY-OPT-END

// ... mlir code ...
```