### PR TITLE
[tools]: Bump LLVM to mainline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.dat
 **/node_modules/
 **/_book/
 .gdbinit
+.bloop/

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682786779,
-        "narHash": "sha256-m7QFzPS/CE8hbkbIVK4UStihAQMtczr0vSpOgETOM1g=",
+        "lastModified": 1685836261,
+        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b",
+        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           deps = with pkgs; [
             rv32-clang
             glibc_multi
-            legacyLLVM.bintools
+            llvmForDev.bintools
 
             cmake
             libargs
@@ -53,7 +53,7 @@
         in
         {
           legacyPackages = pkgs;
-          devShell = pkgs.mkShell.override { stdenv = pkgs.legacyLLVM.stdenv; } {
+          devShell = pkgs.mkShell.override { stdenv = pkgs.llvmForDev.stdenv; } {
             buildInputs = deps;
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           deps = with pkgs; [
             rv32-clang
             glibc_multi
-            myLLVM.bintools
+            legacyLLVM.bintools
 
             cmake
             libargs
@@ -53,7 +53,7 @@
         in
         {
           legacyPackages = pkgs;
-          devShell = pkgs.mkShell.override { stdenv = pkgs.myLLVM.stdenv; } {
+          devShell = pkgs.mkShell.override { stdenv = pkgs.legacyLLVM.stdenv; } {
             buildInputs = deps;
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             python3
             go
             ammonite
+            metals
             gnused
             coreutils
             gnumake

--- a/nix/buddy-mlir.nix
+++ b/nix/buddy-mlir.nix
@@ -12,14 +12,14 @@
 let
   llvm = stdenv.mkDerivation rec {
     pname = "llvm-project";
-    version = "unstable-2022-12-17";
+    version = "unstable-2023-05-02";
     requiredSystemFeatures = [ "big-parallel" ];
     nativeBuildInputs = [ cmake ninja python3 ];
     src = fetchFromGitHub {
       owner = "llvm";
       repo = pname;
-      rev = "e31d27e46048ccc3294d6b215dc778b3390e7834";
-      hash = "sha256-CM3+amf2SpOiUBzdnO7sryTwmGcC0NVabNNvuatcCDQ=";
+      rev = "8f966cedea594d9a91e585e88a80a42c04049e6c";
+      hash = "sha256-g2cYk3/iyUvmIG0QCQpYmWj4L2H4znx9KbuA5TvIjrc=";
     };
     cmakeDir = "../llvm";
     cmakeFlags = [
@@ -44,12 +44,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "buddy-mlir";
-  version = "unstable-2023-05-01";
+  version = "unstable-2023-05-26";
   src = fetchFromGitHub {
     owner = "buddy-compiler";
     repo = pname;
-    rev = "2900b35cfd5ff34e1608b90d04f9dd9f41296f91";
-    hash = "sha256-3qduRyjOQKTDRdOpTJirD0Wm14BuvdJLx2IIWHDMD0g=";
+    rev = "74c18e6963cf4781be254d3c5d963b36c0642ba4";
+    hash = "sha256-Wx/QQrELfOT0h4B8hF9EPZKn4yVHBZeYh3Wm85Jpq60=";
   };
 
   ninjaFlags = [ "buddy-translate" ];

--- a/nix/fix-clang-build.patch
+++ b/nix/fix-clang-build.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,10 +134,6 @@
+       endif()
+     endif()
+ 
+-    if (NOT TARGET llvm_gtest)
+-        message(FATAL_ERROR "llvm-gtest not found. Please install llvm-gtest or disable tests with -DLLVM_INCLUDE_TESTS=OFF")
+-    endif()
+-
+     if(LLVM_LIT)
+       # Define the default arguments to use with 'lit', and an option for the user
+       # to override.

--- a/nix/gnu-install-dirs.patch
+++ b/nix/gnu-install-dirs.patch
@@ -1,0 +1,153 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 45399dc0537e..5d946e9e6583 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -942,7 +942,7 @@ if (NOT TENSORFLOW_AOT_PATH STREQUAL "")
+   add_subdirectory(${TENSORFLOW_AOT_PATH}/xla_aot_runtime_src
+     ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/tf_runtime)
+   install(TARGETS tf_xla_runtime EXPORT LLVMExports
+-    ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT tf_xla_runtime)
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX} COMPONENT tf_xla_runtime)
+   set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS tf_xla_runtime)
+   # Once we add more modules, we should handle this more automatically.
+   if (DEFINED LLVM_OVERRIDE_MODEL_HEADER_INLINERSIZEMODEL)
+diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
+index 057431208322..56f0dcb258da 100644
+--- a/cmake/modules/AddLLVM.cmake
++++ b/cmake/modules/AddLLVM.cmake
+@@ -844,8 +844,8 @@ macro(add_llvm_library name)
+       get_target_export_arg(${name} LLVM export_to_llvmexports ${umbrella})
+       install(TARGETS ${name}
+               ${export_to_llvmexports}
+-              LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
+-              ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT ${name}
++              LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" COMPONENT ${name}
++              ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" COMPONENT ${name}
+               RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name})
+ 
+       if (NOT LLVM_ENABLE_IDE)
+@@ -2007,7 +2007,7 @@ function(llvm_install_library_symlink name dest type)
+   set(full_name ${CMAKE_${type}_LIBRARY_PREFIX}${name}${CMAKE_${type}_LIBRARY_SUFFIX})
+   set(full_dest ${CMAKE_${type}_LIBRARY_PREFIX}${dest}${CMAKE_${type}_LIBRARY_SUFFIX})
+ 
+-  set(output_dir lib${LLVM_LIBDIR_SUFFIX})
++  set(output_dir ${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX})
+   if(WIN32 AND "${type}" STREQUAL "SHARED")
+     set(output_dir "${CMAKE_INSTALL_BINDIR}")
+   endif()
+@@ -2312,16 +2312,16 @@ function(llvm_setup_rpath name)
+ 
+   if (APPLE)
+     set(_install_name_dir INSTALL_NAME_DIR "@rpath")
+-    set(_install_rpath "@loader_path/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath "@loader_path/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+   elseif(${CMAKE_SYSTEM_NAME} MATCHES "AIX" AND BUILD_SHARED_LIBS)
+     # $ORIGIN is not interpreted at link time by aix ld.
+     # Since BUILD_SHARED_LIBS is only recommended for use by developers,
+     # hardcode the rpath to build/install lib dir first in this mode.
+     # FIXME: update this when there is better solution.
+-    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath "${LLVM_LIBRARY_OUTPUT_INTDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+   elseif(UNIX)
+-    set(_build_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_build_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
+-    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}")
++    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
+     if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
+       set_property(TARGET ${name} APPEND_STRING PROPERTY
+                    LINK_FLAGS " -Wl,-z,origin ")
+@@ -2358,11 +2357,7 @@ function(llvm_setup_rpath name)
+   # On AIX, the tool chain doesn't support modifying rpaths/libpaths for XCOFF
+   # on install at the moment, so BUILD_WITH_INSTALL_RPATH is required.
+   if("${CMAKE_BUILD_RPATH}" STREQUAL "")
+-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin|AIX")
+-      set_property(TARGET ${name} PROPERTY BUILD_WITH_INSTALL_RPATH ON)
+-    else()
+-      set_property(TARGET ${name} APPEND PROPERTY BUILD_RPATH "${_build_rpath}")
+-    endif()
++    set_property(TARGET ${name} PROPERTY BUILD_WITH_INSTALL_RPATH ON)
+   endif()
+
+   set_target_properties(${name} PROPERTIES
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index 891c9e6d618c..8d963f3b0069 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -147,9 +147,9 @@ function(add_ocaml_library name)
+   endforeach()
+ 
+   if( APPLE )
+-    set(ocaml_rpath "@executable_path/../../../lib${LLVM_LIBDIR_SUFFIX}")
++    set(ocaml_rpath "@executable_path/../../../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
+   elseif( UNIX )
+-    set(ocaml_rpath "\\$ORIGIN/../../../lib${LLVM_LIBDIR_SUFFIX}")
++    set(ocaml_rpath "\\$ORIGIN/../../../${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
+   endif()
+   list(APPEND ocaml_flags "-ldopt" "-Wl,-rpath,${ocaml_rpath}")
+ 
+diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
+index d4b0ab959148..26ed981fd09f 100644
+--- a/cmake/modules/CMakeLists.txt
++++ b/cmake/modules/CMakeLists.txt
+@@ -128,7 +128,7 @@ set(LLVM_CONFIG_INCLUDE_DIRS
+   )
+ list(REMOVE_DUPLICATES LLVM_CONFIG_INCLUDE_DIRS)
+ 
+-extend_path(LLVM_CONFIG_LIBRARY_DIR "\${LLVM_INSTALL_PREFIX}" "lib\${LLVM_LIBDIR_SUFFIX}")
++extend_path(LLVM_CONFIG_LIBRARY_DIR "\${LLVM_INSTALL_PREFIX}" "${CMAKE_INSTALL_LIBDIR}\${LLVM_LIBDIR_SUFFIX}")
+ set(LLVM_CONFIG_LIBRARY_DIRS
+   "${LLVM_CONFIG_LIBRARY_DIR}"
+   # FIXME: Should there be other entries here?
+diff --git a/docs/CMake.rst b/docs/CMake.rst
+index 879b7b231d4c..9c31d14e8950 100644
+--- a/docs/CMake.rst
++++ b/docs/CMake.rst
+@@ -250,7 +250,7 @@ description is in `LLVM-related variables`_ below.
+ **LLVM_LIBDIR_SUFFIX**:STRING
+   Extra suffix to append to the directory where libraries are to be
+   installed. On a 64-bit architecture, one could use ``-DLLVM_LIBDIR_SUFFIX=64``
+-  to install libraries to ``/usr/lib64``.
++  to install libraries to ``/usr/lib64``. See also ``CMAKE_INSTALL_LIBDIR``.
+ 
+ **LLVM_PARALLEL_{COMPILE,LINK}_JOBS**:STRING
+   Building the llvm toolchain can use a lot of resources, particularly
+@@ -284,6 +284,10 @@ manual, or execute ``cmake --help-variable VARIABLE_NAME``.
+   The path to install executables, relative to the *CMAKE_INSTALL_PREFIX*.
+   Defaults to "bin".
+ 
++**CMAKE_INSTALL_LIBDIR**:PATH
++  The path to install libraries, relative to the *CMAKE_INSTALL_PREFIX*.
++  Defaults to "lib".
++
+ **CMAKE_INSTALL_INCLUDEDIR**:PATH
+   The path to install header files, relative to the *CMAKE_INSTALL_PREFIX*.
+   Defaults to "include".
+diff --git a/tools/llvm-config/BuildVariables.inc.in b/tools/llvm-config/BuildVariables.inc.in
+index 370005cd8d7d..7e790bc52111 100644
+--- a/tools/llvm-config/BuildVariables.inc.in
++++ b/tools/llvm-config/BuildVariables.inc.in
+@@ -23,6 +23,7 @@
+ #define LLVM_CXXFLAGS "@LLVM_CXXFLAGS@"
+ #define LLVM_BUILDMODE "@LLVM_BUILDMODE@"
+ #define LLVM_LIBDIR_SUFFIX "@LLVM_LIBDIR_SUFFIX@"
++#define LLVM_INSTALL_LIBDIR "@CMAKE_INSTALL_LIBDIR@"
+ #define LLVM_INSTALL_INCLUDEDIR "@CMAKE_INSTALL_INCLUDEDIR@"
+ #define LLVM_INSTALL_PACKAGE_DIR "@LLVM_INSTALL_PACKAGE_DIR@"
+ #define LLVM_TARGETS_BUILT "@LLVM_TARGETS_BUILT@"
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 2c6c55f89d38..f6d2068a0827 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -369,7 +369,11 @@ int main(int argc, char **argv) {
+       sys::fs::make_absolute(ActivePrefix, Path);
+       ActiveBinDir = std::string(Path.str());
+     }
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
++    {
++      SmallString<256> Path(LLVM_INSTALL_LIBDIR LLVM_LIBDIR_SUFFIX);
++      sys::fs::make_absolute(ActivePrefix, Path);
++      ActiveLibDir = std::string(Path.str());
++    }
+     {
+       SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
+       sys::fs::make_absolute(ActivePrefix, Path);

--- a/nix/rv32-compilerrt.nix
+++ b/nix/rv32-compilerrt.nix
@@ -1,9 +1,9 @@
-{ legacyLLVM, myLLVMTools, fetchFromGitHub, cmake, python3, glibc_multi  }:
+{ llvmForDev, llvmToolsForRV32Clang, fetchFromGitHub, cmake, python3, glibc_multi  }:
 
 let
   pname = "rv-compilerrt";
-  version = myLLVMTools.llvm.version;
-  rev = myLLVMTools.llvm.monorepoSrc.rev;
+  version = llvmToolsForRV32Clang.llvm.version;
+  rev = llvmToolsForRV32Clang.llvm.monorepoSrc.rev;
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
@@ -11,7 +11,7 @@ let
     sha256 = "sha256-g2cYk3/iyUvmIG0QCQpYmWj4L2H4znx9KbuA5TvIjrc=";
   };
 in
-legacyLLVM.stdenv.mkDerivation {
+llvmForDev.stdenv.mkDerivation {
   sourceRoot = "${src.name}/compiler-rt";
   inherit src version pname;
   nativeBuildInputs = [ cmake python3 glibc_multi ];

--- a/nix/rv32-compilerrt.nix
+++ b/nix/rv32-compilerrt.nix
@@ -1,16 +1,17 @@
-{ myLLVM, fetchFromGitHub, cmake, python3, glibc_multi }:
+{ legacyLLVM, myLLVMTools, fetchFromGitHub, cmake, python3, glibc_multi  }:
 
 let
   pname = "rv-compilerrt";
-  version = myLLVM.llvm.version;
+  version = myLLVMTools.llvm.version;
+  rev = myLLVMTools.llvm.monorepoSrc.rev;
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
-    rev = version;
-    sha256 = "sha256-vffu4HilvYwtzwgq+NlS26m65DGbp6OSSne2aje1yJE=";
+    rev = rev;
+    sha256 = "sha256-g2cYk3/iyUvmIG0QCQpYmWj4L2H4znx9KbuA5TvIjrc=";
   };
 in
-myLLVM.stdenv.mkDerivation {
+legacyLLVM.stdenv.mkDerivation {
   sourceRoot = "${src.name}/compiler-rt";
   inherit src version pname;
   nativeBuildInputs = [ cmake python3 glibc_multi ];

--- a/nix/rv32-musl.nix
+++ b/nix/rv32-musl.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, legacyLLVM, rv32-compilerrt }:
+{ fetchFromGitHub, llvmForDev, rv32-compilerrt }:
 let
   pname = "musl";
   version = "a167b20fd395a45603b2d36cbf96dcb99ccedd60";
@@ -9,9 +9,9 @@ let
     sha256 = "sha256-kFOTlJ5ka5h694EBbwNkM5TLHlFg6uJsY7DK5ImQ8mY=";
   };
 in
-legacyLLVM.stdenv.mkDerivation {
+llvmForDev.stdenv.mkDerivation {
   inherit src pname version;
-  nativeBuildInputs = [ legacyLLVM.bintools ];
+  nativeBuildInputs = [ llvmForDev.bintools ];
   configureFlags = [
     "--target=riscv32-none-elf"
     "--enable-static"

--- a/nix/rv32-musl.nix
+++ b/nix/rv32-musl.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, myLLVM, rv32-compilerrt }:
+{ fetchFromGitHub, legacyLLVM, rv32-compilerrt }:
 let
   pname = "musl";
   version = "a167b20fd395a45603b2d36cbf96dcb99ccedd60";
@@ -9,9 +9,9 @@ let
     sha256 = "sha256-kFOTlJ5ka5h694EBbwNkM5TLHlFg6uJsY7DK5ImQ8mY=";
   };
 in
-myLLVM.stdenv.mkDerivation {
+legacyLLVM.stdenv.mkDerivation {
   inherit src pname version;
-  nativeBuildInputs = [ myLLVM.bintools ];
+  nativeBuildInputs = [ legacyLLVM.bintools ];
   configureFlags = [
     "--target=riscv32-none-elf"
     "--enable-static"

--- a/tests/cases/buddy/axpy-masked.mlir
+++ b/tests/cases/buddy/axpy-masked.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/conv.mlir
+++ b/tests/cases/buddy/conv.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/hello.mlir
+++ b/tests/cases/buddy/hello.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/matmul.mlir
+++ b/tests/cases/buddy/matmul.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/maxvl-tail-setvl-front.mlir
+++ b/tests/cases/buddy/maxvl-tail-setvl-front.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/rvv-vp-intrinsic-add-scalable.mlir
+++ b/tests/cases/buddy/rvv-vp-intrinsic-add-scalable.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/rvv-vp-intrinsic-add.mlir
+++ b/tests/cases/buddy/rvv-vp-intrinsic-add.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/stripmining.mlir
+++ b/tests/cases/buddy/stripmining.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/buddy/vectoradd.mlir
+++ b/tests/cases/buddy/vectoradd.mlir
@@ -1,7 +1,7 @@
 // BUDDY-OPT
 // --lower-affine --convert-scf-to-cf --convert-math-to-llvm
 // --lower-vector-exp --lower-rvv=rv32
-// --convert-vector-to-llvm --convert-memref-to-llvm
+// --convert-vector-to-llvm --finalize-memref-to-llvm
 // --convert-arith-to-llvm --convert-func-to-llvm
 // --reconcile-unrealized-casts
 // BUDDY-OPT-END

--- a/tests/cases/intrinsic/conv2d_less_m2.c
+++ b/tests/cases/intrinsic/conv2d_less_m2.c
@@ -31,15 +31,15 @@ void conv2d(int32_t *restrict output, int32_t const *restrict img,
         while (avl > 0) {
           // TODO: exchange vl-loop and kJ loop, can be more cache friendly
 
-          size_t vl = vsetvl_e32m2(avl);
+          size_t vl = __riscv_vsetvl_e32m2(avl);
 
-          vint32m2_t imgVec = vle32_v_i32m2(imgPtr, vl);
-          vint32m2_t mulVec = vmul_vx_i32m2(imgVec, K, vl);
+          vint32m2_t imgVec = __riscv_vle32_v_i32m2(imgPtr, vl);
+          vint32m2_t mulVec = __riscv_vmul_vx_i32m2(imgVec, K, vl);
 
-          vint32m2_t outVec = vle32_v_i32m2(outPtr, vl);
-          vint32m2_t resVec = vadd_vv_i32m2(outVec, mulVec, vl);
+          vint32m2_t outVec = __riscv_vle32_v_i32m2(outPtr, vl);
+          vint32m2_t resVec = __riscv_vadd_vv_i32m2(outVec, mulVec, vl);
 
-          vse32_v_i32m2(outPtr, resVec, vl);
+          __riscv_vse32_v_i32m2(outPtr, resVec, vl);
 
           avl -= vl;
           imgPtr += vl;


### PR DESCRIPTION
This commit add metals for scala, and bump buddy-mlir to latest commit to have buddy-lsp-server for mlir.

To have buddy-lsp-server working, this pr also bump llvm to mainline version to have I2p1 extension support.