### PR TITLE
[test] Enable RISC-V F in assembly to support vector FP operations

### DIFF
--- a/tests/cases/asm/main.S
+++ b/tests/cases/asm/main.S
@@ -1,6 +1,6 @@
     .globl start
 start:
-    li a0, 0x200 # MSTATUS_VS & (MSTATUS_VS >> 1)
+    li a0, 0x2200 # MSTATUS_VS & (MSTATUS_VS >> 1)
     csrs mstatus, a0
     csrwi vcsr, 0
 

--- a/tests/cases/buddy/main.S
+++ b/tests/cases/buddy/main.S
@@ -1,6 +1,6 @@
     .globl start
 start:
-    li a0, 0x200 # MSTATUS_VS & (MSTATUS_VS >> 1)
+    li a0, 0x2200 # MSTATUS_VS & (MSTATUS_VS >> 1)
     csrs mstatus, a0
     csrwi vcsr, 0
 

--- a/tests/cases/intrinsic/main.S
+++ b/tests/cases/intrinsic/main.S
@@ -1,6 +1,6 @@
     .globl start
 start:
-    li a0, 0x200 # MSTATUS_VS & (MSTATUS_VS >> 1)
+    li a0, 0x2200 # MSTATUS_VS & (MSTATUS_VS >> 1)
     csrs mstatus, a0
     csrwi vcsr, 0
 


### PR DESCRIPTION
When testing mlir demos in vector repo, the generated assembly will be called in file "main.s", where defines which RISC-V extended instruction set to use. Though FP operations has been supported in hardware's side, RISC-V "F" hasn't been enabled for testing:< which leads to `spike illinstr` when running FP vector operations in buddy cases. This PR enables RISC-V "F" in assembly for all the tests.