### PR TITLE
[test] add new script to generate test artifacts

### DIFF
--- a/.github/scripts/ci.sc
+++ b/.github/scripts/ci.sc
@@ -34,3 +34,46 @@ def runTest(root: os.Path, jobs: String, outputFile: os.Path) = {
     throw new Exception(s"runTest failed with exit code ${exitCode}")
   }
 }
+
+@main
+def genTestElf(testDir: os.Path, outDir: os.Path) = {
+  // Prepare output directory
+  //   output/
+  //      configs/
+  //      tests/
+  //        mlir/
+  //        asm/
+  //        .../
+  os.remove.all(outDir)
+  // Ensure there is no cache
+  os.remove.all(testDir / "out")
+  os.makeDir.all(outDir)
+  val outConfigDir = outDir / "configs"
+  os.makeDir.all(outConfigDir)
+  val outElfDir = outDir / "tests"
+  os.makeDir.all(outElfDir)
+
+  os.proc("mill", "resolve", "_[_]")
+    .call(testDir).out.text
+    .split('\n').toSeq
+    .foreach(task => {
+      // Compile and get abosolute path to the final elf binary
+      val rawElfPath = os.proc("mill", "show", s"$task.elf").call(testDir).out.text
+      val elfPath = os.Path(ujson.read(rawElfPath).str.split(':')(2))
+      // Get original test config for this task
+      val rawTestConfig = os.proc("mill", "show", s"$task.testConfig").call(testDir).out.text
+      val testConfig = ujson.read(rawTestConfig)
+      val taskType = testConfig("type").str
+      // { elf: { path: "../tests/$type/$elf" } }
+      testConfig("elf") = ujson.Obj("path" -> s"../tests/$taskType/${elfPath.last}")
+
+      val testCategory = outElfDir / taskType
+      os.makeDir.all(testCategory)
+      os.move(elfPath, testCategory / elfPath.last)
+
+      os.write(outConfigDir / s"${elfPath.baseName}-$taskType.json", ujson.write(testConfig))
+    })
+
+  os.proc("tar", "--create", "--gzip", "--file", "test-elf.tar.gz", outDir).call()
+  os.remove.all(outDir)
+}

--- a/.github/scripts/ci.sc
+++ b/.github/scripts/ci.sc
@@ -74,6 +74,6 @@ def genTestElf(testDir: os.Path, outDir: os.Path) = {
       os.write(outConfigDir / s"${elfPath.baseName}-$taskType.json", ujson.write(testConfig))
     })
 
-  os.proc("tar", "--create", "--gzip", "--file", "test-elf.tar.gz", outDir).call()
+  os.proc("tar", "--create", "--gzip", "--file", "tests-artifacts.tar.gz", outDir).call()
   os.remove.all(outDir)
 }

--- a/.github/workflows/gen-test-elf.yml
+++ b/.github/workflows/gen-test-elf.yml
@@ -1,0 +1,33 @@
+name: Generate Test elf
+on:
+  push:
+    paths:
+      - 'tests/**'
+  pull_request:
+    paths:
+      - 'tests/**'
+jobs:
+  gen-test-artifacts:
+    runs-on: [self-hosted, linux]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - run: sudo -E .github/setup-actions.sh
+        env:
+          AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
+          CACHE_PRIV_KEY: ${{secrets.CACHE_PRIV_KEY}}
+          CACHE_DOMAIN: ${{secrets.CACHE_DOMAIN}}
+      - uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            post-build-hook = /etc/nix/upload-to-cache.sh
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= minio.inner.fi.c-3.moe:gDg5SOIH65O0tTV89dUawME5BTmduWWaA7as/cqvevM=
+            extra-substituters = https://${{secrets.CACHE_DOMAIN}}/nix
+      - run: nix develop -c make gen-tests-artifacts
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: tests-artifacts.tar.gz
+          tag_name: ${{ GITHUB_SHA }}

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ ci-all-tests:
 	echo -n matrix= >> $$GITHUB_OUTPUT
 	amm .github/scripts/ci.sc allJson $(RUNNERS) . ./all.json
 	cat ./all.json >> $$GITHUB_OUTPUT
+
+gen-tests-artifacts:
+	amm .github/scripts/ci.sc genTestElf ./tests ./tests-artifacts


### PR DESCRIPTION
This script will compile all the tests into elf binaries, append the elf binary path to the corresponding test config file, and pack them into a single tarball.

This PR is now on hold until #269 can be merged and the following CI workflow is done.