### PR TITLE
[ci] add new workflow to release testcase elf on GitHub

### DIFF
--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -85,10 +85,9 @@ jobs:
     if: github.event.pull_request.merged == true && always()
     needs: [ci]
     runs-on: [self-hosted, linux]
+    outputs:
+      should_release_testcase: ${{ steps.testcase_status.outputs.run_release }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/download-artifact@v3
         with:
           name: results
@@ -99,3 +98,88 @@ jobs:
       - run: |
           echo -e "\n## Still failing tests\n" >> $GITHUB_STEP_SUMMARY
           find . -name 'fail-test-*.md' -exec bash -c 'cat {} >> $GITHUB_STEP_SUMMARY' \;
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: master
+      - id: testcase_status
+        run: |
+          # Run release only when changes is in tests/ directory or is nix/rvv-testcase.nix or is nix/rvv-testcase-unwrapped.nix
+          git diff --name-only HEAD HEAD^ | grep -q "^tests/\|^nix/rvv-testcase" && \
+            echo "run_release=true" >> $GITHUB_OUTPUT && \
+            echo "Release job triggered"
+
+  release:
+    runs-on: [self-hosted, linux]
+    needs: report
+    if: ${{ needs.report.outputs.should_release_testcase == 'true' }}
+    steps:
+      - run: sudo -E .github/setup-actions.sh
+        env:
+          AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
+          CACHE_PRIV_KEY: ${{secrets.CACHE_PRIV_KEY}}
+          CACHE_DOMAIN: ${{secrets.CACHE_DOMAIN}}
+      - uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            post-build-hook = /etc/nix/upload-to-cache.sh
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= minio.inner.fi.c-3.moe:gDg5SOIH65O0tTV89dUawME5BTmduWWaA7as/cqvevM=
+            extra-substituters = https://${{secrets.CACHE_DOMAIN}}/nix
+            sandbox = relaxed
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: master
+      - run: |
+          nix build .#testcase --print-build-logs --out-link result
+          tar czvf rvv-testcase.tar.gz --directory ./result .
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        id: step-release
+        if: success()
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          automatic_release_tag: "latest"
+          title: "Testcase Release ${{ github.sha }}"
+          files: ./rvv-testcase.tar.gz
+      - if: success()
+        id: step-bump
+        run: |
+          NIX_FILE="./nix/rvv-testcase-unwrapped.nix"
+          NIX_EXPR_PREFIX="with import <nixpkgs> {}; let pkg = callPackage $NIX_FILE {}; in"
+          get_src_url() {
+            nix eval --impure --raw --expr "$NIX_EXPR_PREFIX pkg.src.url"
+          }
+          get_output_hash() {
+            nix eval --impure --raw --expr "$NIX_EXPR_PREFIX pkg.src.outputHash"
+          }
+          src_url=$(get_src_url)
+          echo "Updating src url: $src_url"
+          new_file=$(nix-prefetch-url $src_url --print-path --type sha256 | tail -n1)
+          echo "File downloaded to $new_file"
+          new_hash=$(nix hash file --base16 --type sha256 --sri $new_file)
+          echo "Generated new hash: $new_hash"
+          old_hash=$(get_output_hash)
+          sed -i "s|$old_hash|$new_hash|" $NIX_FILE
+          new_hash=$(get_output_hash)
+          if [[ "$old_hash" = "$new_hash" ]]; then
+            echo "No update"
+            echo "CREATE_PR=0" >> $GITHUB_OUTPUT
+          else
+            echo "Hash is updated from $old_hash to $new_hash"
+            echo "CREATE_PR=1" >> $GITHUB_OUTPUT
+          fi
+      - if: ${{ steps.step-bump.outputs.CREATE_PR == '1' }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: ./nix/rvv-testcase-unwrapped.nix
+          commit-message: "[nix] bump testcase"
+          branch: nix-testcase-bump
+          delete-branch: true
+          title: "[nix] bump testcase"
+          body: "Bump rvv-testcase-unwrapped.nix"
+          reviewers: |
+            avimitin
+            sequencer

--- a/nix/rvv-testcase-unwrapped.nix
+++ b/nix/rvv-testcase-unwrapped.nix
@@ -1,0 +1,14 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "rvv-testcase-unwrapped";
+  version = "latest";
+  src = fetchurl {
+    url = "https://github.com/sequencer/vector/releases/download/${version}/rvv-testcase.tar.gz";
+    sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+  installPhase = ''
+    mkdir $out
+    cp -r $src/* $out
+  '';
+}


### PR DESCRIPTION
Implemented feature:

- Run testcase build when tests/ directory, nix/rvv-testcase-* file got modified
- Automatically upload test case artifact to GitHub release
- Automatically create new PR to bump nix hash when test case is updated