### PR TITLE
[nix] add "--interactive" as default flag for mill

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -37,6 +37,8 @@ rec {
   mill = let jre = final.jdk21; in
     (prev.mill.override { inherit jre; }).overrideAttrs (_: {
       passthru = { inherit jre; };
+      # --interactive implies --no-server
+      postInstall = ''wrapProgram $out/bin/mill --add-flags "--interactive"'';
     });
 
   # some symbols in newlib libgloss uses ecall, which does not work in emulator


### PR DESCRIPTION
Using mill without "-i/--interactive" or "--no-server" will run a mill build server automatically. The build server doesn't inherit or update environment when user invoke mill at command-line, which is hard for developers to debug.

As the T1 project doesn't use mill build server for a long time, I decided to add the "-i" flag as default for mill. If someday someone wants to use the unwrapped version, they can use the .mill-unwrapped executable contains in the same package.