### PR TITLE
[rocketv] Interlock vector .vf ops against an in-flight scalar FP producer

### DIFF
--- a/rocketv/src/RocketCore.scala
+++ b/rocketv/src/RocketCore.scala
@@ -1342,8 +1342,19 @@ class Rocket(val parameter: RocketParameter)
         Option.when(usingVector)(exRegDecodeOutput(parameter.decoderParameter.vector)).getOrElse(false.B)
     val dataHazardEx:   Bool         =
       exRegDecodeOutput(parameter.decoderParameter.wxd) && checkHazards(hazardTargets, _ === exWaddr)
+    // A vector `.vf` instruction reads its scalar operand from the F register file
+    // (decoded as vectorReadFRs1). Exactly like a scalar FP consumer it must interlock
+    // against an in-flight FP-register producer (fmv.w.x, flw, ...) that is still in
+    // EX/MEM/WB; otherwise it issues to the vector unit with a stale frs1. The
+    // scoreboard-based idStallFpu below already covers vectorReadFRs1, but these
+    // EX/MEM/WB checks did not, leaving a 1-2 cycle window of stale scalar reads.
+    val idReadFRs1:     Bool         =
+      idDecodeOutput(parameter.decoderParameter.fp) ||
+        Option
+          .when(usingVector)(idDecodeOutput(parameter.decoderParameter.vectorReadFRs1))
+          .getOrElse(false.B)
     val fpDataHazardEx: Option[Bool] = fpHazardTargets.map(fpHazardTargets =>
-      idDecodeOutput(parameter.decoderParameter.fp) && exRegDecodeOutput(
+      idReadFRs1 && exRegDecodeOutput(
         parameter.decoderParameter.wfd
       ) && checkHazards(fpHazardTargets, _ === exWaddr)
     )
@@ -1366,7 +1377,7 @@ class Rocket(val parameter: RocketParameter)
     val dataHazardMem:   Bool         =
       memRegDecodeOutput(parameter.decoderParameter.wxd) && checkHazards(hazardTargets, _ === memWaddr)
     val fpDataHazardMem: Option[Bool] = fpHazardTargets.map(fpHazardTargets =>
-      idDecodeOutput(parameter.decoderParameter.fp) &&
+      idReadFRs1 &&
         memRegDecodeOutput(parameter.decoderParameter.wfd) &&
         checkHazards(fpHazardTargets, _ === memWaddr)
     )
@@ -1377,7 +1388,7 @@ class Rocket(val parameter: RocketParameter)
       wbRegDecodeOutput(parameter.decoderParameter.wxd) && checkHazards(hazardTargets, _ === wbWaddr)
     val fpDataHazardWb: Bool = fpHazardTargets
       .map(fpHazardTargets =>
-        idDecodeOutput(parameter.decoderParameter.fp) &&
+        idReadFRs1 &&
           wbRegDecodeOutput(parameter.decoderParameter.wfd) &&
           checkHazards(fpHazardTargets, _ === wbWaddr)
       )


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

A vector .vf instruction reads its scalar operand from an f register
(vectorReadFRs1). The three FP data hazard checks fpDataHazardEx/Mem/Wb gate on
the fp decode bit, which a vector instruction does not set, so a .vf reader was
not held for an f-register producer (fmv.w.x, flw, ...) only one or two stages
ahead. The scalar core then handed the vector unit a stale frs1 and the whole
vector instruction computed on the wrong scalar. With zero or one instruction
between the producer and the .vf reader the value is stale; with two or more it
is correct.

The scoreboard stall (idStallFpu) and fpu.valid already combine fp with
vectorReadFRs1; only these three EX/MEM/WB checks were missed. Add the vector
read of frs1 to the same three checks. This only adds interlocks that were
missing and matches the scalar FP path exactly, so it cannot introduce a wrong
result.

Found by differential testing against spike (T1 offline difftest). A vfdiv.vf
whose divisor is set by an fmv.w.x immediately before it reads the register as
its reset zero, so every active element becomes +/-inf; the fix makes it read the
written value. Verified on a rebuilt blastoise emulator, including a gap sweep
(0-1 gap stale, 2+ correct) and a 24-program random batch with no regression.