### PR TITLE
[rtl] Fix vasub averaging that zeroes the max-difference element

### DIFF
--- a/t1/src/LaneAdder.scala
+++ b/t1/src/LaneAdder.scala
@@ -253,16 +253,29 @@ class LaneAdder(val parameter: LaneAdderParam) extends VFUModule with Serializab
         Seq(
           Mux(
             subRequest.sign,
-            // data(6) && anyNegativeVec(index) -> 任意操作数是负的,需要做符号位扩展, 否则占据data(6)的是+的上溢出
-            // eg： 7f + 7 = 86 -average-> 43(不符号扩展)
-            //      f8 + 0 = f8 -average-> fc(符号扩展)
-            // !isSub || !data(7)
-            //      7f - 0 = 7f + ff + 1 + 1 = 180 -average-> c0(需要去掉最高位) -> 40
-            // allNegativeVec(index) && data(7):
-            // 包含特殊的下溢出： average(0xfff8 - 0x7fff) = 0x10ffd >> 1
+            // The averaging halve is a logical >>1, so the element's top bit is dropped at
+            // the element boundary and has to be rebuilt here.
+            //
+            // Write the value being halved as V = P + Q + inc, where P and Q are the two
+            // adder operands (already complemented for a subtract) and inc is the subtract
+            // carry plus the rounding bit. Reading P and Q as signed gives
+            //   V_signed = V - 2^SEW * (P_sign + Q_sign)
+            // so the signed average is
+            //   V_signed >> 1 = (V >> 1) - 2^(SEW-1) * (P_sign + Q_sign).
+            // Modulo the element, -2^(SEW-1) and +2^(SEW-1) are the same, so the result is
+            // just the halved sum with its top bit flipped exactly when one of the two
+            // operands is negative and the other is not.
+            //
+            // eg: 7f + 07 -average-> 43 (both non-negative, top bit kept)
+            //     f8 + 00 -average-> fc (one negative, top bit flipped, sign extended)
+            //     7f - 00  = 7f + ff + 1 + 1 = 180 -average-> c0, flipped -> 40
+            //     7f - 80  = 7f + 7f + 1 + 1 = 100 -average-> 80, kept    -> 80
+            // The last case is the one the previous form got wrong: it forced the top bit to
+            // zero whenever both operands were non-negative, which drops the 2^(SEW-1) that
+            // vasub produces at the largest positive minus the most negative element.
             Mux(
               subRequest.average && isFirstBlock(index),
-              (allNegativeVec(index) && data(7)) || (data(6) && anyNegativeVec(index) && (!isSub || !data(7))),
+              data(7) ^ (anyNegativeVec(index) && !allNegativeVec(index)),
               data(7)
             ),
             (subRequest.average && isFirstBlock(index) && isSub) ^ data(7)


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

`vasub` returns the wrong result for one operand pair per element width:
the largest positive element minus the most negative one. At e8, source
0x7f and scalar 0x80 should give 0x80 (spike), but T1 returns 0x00. Same
at e16 (0x7fff - 0x8000) and e32. Only the element's top bit is wrong.
Silent wrong result, no trap.

### Root cause

The averaging halve is a logical >>1 across the word, so each element's
top bit is dropped at the boundary and rebuilt in `LaneAdder.scala`. The
old reconstruction forces that bit to zero whenever both adder operands
are non-negative. `vasub` at the extreme gives P = ~0x80 = 0x7f and
Q = 0x7f (both non-negative) with halved sum 0x80, whose top bit is a
real one. It gets discarded and the element becomes 0x00. The unsigned
forms take the other Mux branch and are unaffected.

### Fix

The signed average is the halved sum with its top bit flipped when one
operand is negative and the other is not, so the correct bit is
`data(7) ^ (anyNegativeVec(index) && !allNegativeVec(index))`.

### Verification

Offline difference test against spike: an exhaustive e8 sweep of
vasub.vv/vaadd.vv (plus vasubu/vaaddu controls) over all four vxrm modes,
655360 operand pairs, matches spike after the fix and diverges before it.