### PR TITLE
[rtl] Seed reduction accumulators to the operation identity

### DIFF
--- a/t1/src/laneStage/LaneExecutionBridge.scala
+++ b/t1/src/laneStage/LaneExecutionBridge.scala
@@ -515,16 +515,90 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean, slotInd
       )
     }
     firstRequestFire.foreach { fr =>
+      // Seed non-element-0 lanes with the op identity, +inf/-inf for fp min/max (0, the fp-add
+      // identity, is wrong for min/max: min(x, 0) collapses the fold to 0)
+      val redFpUop:                           UInt = enqueue.bits.decodeResult(Decoder.uop)
+      // fpExecutionType b10 = Compare (min/max); vfredusum/vfredosum share uop 1000 but are add, gate on Compare
+      val redFpCompare:                       Bool = enqueue.bits.decodeResult(Decoder.fpExecutionType) === "b10".U
+      val redFpMin:                           Bool = enqueue.bits.decodeResult(Decoder.float) && redFpCompare && (redFpUop === "b1000".U)
+      val redFpMax:                           Bool = enqueue.bits.decodeResult(Decoder.float) && redFpCompare && (redFpUop === "b1100".U)
+      def redFpRep(e16: String, e32: String): UInt = Mux1H(
+        enqueue.bits.vSew1H,
+        Seq(0.U(parameter.eLen.W), Fill(parameter.eLen / 16, e16.U(16.W)), Fill(parameter.eLen / 32, e32.U(32.W)))
+      )
+      val redFpIdElem:                        UInt =
+        Mux(
+          redFpMin,
+          redFpRep("h7c00", "h7f800000"),
+          Mux(redFpMax, redFpRep("hfc00", "hff800000"), 0.U(parameter.eLen.W))
+        )
       fr.zipWithIndex.foreach { case (f, i) =>
         when(enqueue.fire && f && enqueue.bits.decodeResult(Decoder.float)) {
           reduceResult.foreach { red =>
-            red(i) := cutUInt(
-              Mux(enqueue.bits.decodeResult(Decoder.fpExecutionType).orR, enqueue.bits.src(1), 0.U),
-              parameter.eLen
-            )(i)
+            // Override only the non-element-0 lanes for fp min/max; keep the original seed otherwise
+            val redFpSeed: UInt = cutUInt(enqueue.bits.src(1), parameter.eLen)(i)
+            red(i) := Mux(
+              enqueue.bits.decodeResult(Decoder.fpExecutionType).orR,
+              if (i == 0) redFpSeed else Mux(redFpMin || redFpMax, redFpIdElem, redFpSeed),
+              0.U
+            )
           }
         }
       }
+    }
+
+    val redAccInitialized: Bool = RegInit(false.B)
+    // Seed the integer reduction accumulator with the op identity, not 0: all-ones for
+    // unsigned-min/and, max-signed for signed-min, min-signed for signed-max (0 only suits add/or/xor/umax)
+    reduceResult.foreach { red =>
+      val redUop:      UInt = enqueue.bits.decodeResult(Decoder.uop)
+      val redSign:     Bool = !enqueue.bits.decodeResult(Decoder.unsigned1)
+      val redIsLogic:  Bool = enqueue.bits.decodeResult(Decoder.logic)
+      val redIsMin:    Bool = !redIsLogic && (redUop === 7.U)
+      val redIsMax:    Bool = !redIsLogic && (redUop === 6.U)
+      val redIsAnd:    Bool = redIsLogic && (redUop === 0.U)
+      val redAllOnes:  UInt = (-1.S(parameter.eLen.W)).asUInt
+      val redSMax:     UInt = Mux1H(
+        enqueue.bits.vSew1H,
+        Seq(
+          Fill(parameter.eLen / 8, "h7f".U(8.W)),
+          Fill(parameter.eLen / 16, "h7fff".U(16.W)),
+          Fill(parameter.eLen / 32, "h7fffffff".U(32.W))
+        )
+      )
+      val redSMin:     UInt = Mux1H(
+        enqueue.bits.vSew1H,
+        Seq(
+          Fill(parameter.eLen / 8, "h80".U(8.W)),
+          Fill(parameter.eLen / 16, "h8000".U(16.W)),
+          Fill(parameter.eLen / 32, "h80000000".U(32.W))
+        )
+      )
+      val redIdentity: UInt = Mux(
+        redIsMin,
+        Mux(redSign, redSMax, redAllOnes),
+        Mux(redIsMax, Mux(redSign, redSMin, 0.U), Mux(redIsAnd, redAllOnes, 0.U))
+      )
+      // Seed once at the start: every group-0 chunk has groupCounter === 0, so redAccInitialized
+      // latches after the first seed so later chunks keep accumulating
+      when(
+        enqueue.fire &&
+          enqueue.bits.decodeResult(Decoder.red) &&
+          !enqueue.bits.decodeResult(Decoder.float) &&
+          !redAccInitialized
+      ) {
+        red.foreach(_ := redIdentity)
+      }
+    }
+    when(
+      enqueue.fire &&
+        enqueue.bits.decodeResult(Decoder.red) &&
+        !enqueue.bits.decodeResult(Decoder.float) &&
+        !redAccInitialized
+    ) {
+      redAccInitialized := true.B
+    }.elsewhen(reduceLastResponse) {
+      redAccInitialized := false.B
     }
 
     // reduce state machine

--- a/t1/src/laneStage/MaskExchangeUnit.scala
+++ b/t1/src/laneStage/MaskExchangeUnit.scala
@@ -403,9 +403,44 @@ class MaskExchangeUnit(parameter: LaneParameter) extends Module {
     reduceResultSize    := log2Ceil(parameter.datapathWidth / 8).U
     when(maskPipeEnqReduce) {
       when(firstFroup && firstLane) {
+        // Fill non-element-0 lanes with the op identity: the old `source1 & enqBitMask` left them
+        // 0, which the horizontal fold collapses (min(x, 0) = 0)
+        val redUop:       UInt = maskPipeEnqReq.decodeResult(Decoder.uop)
+        val redSign:      Bool = !maskPipeEnqReq.decodeResult(Decoder.unsigned1)
+        val redLogic:     Bool = maskPipeEnqReq.decodeResult(Decoder.logic)
+        val redFloat:     Bool = maskPipeEnqReq.decodeResult(Decoder.float)
+        val redIsMin:     Bool = !redLogic && (redUop === 7.U)
+        val redIsMax:     Bool = !redLogic && (redUop === 6.U)
+        val redIsAnd:     Bool = redLogic && (redUop === 0.U)
+        // LaneFloat compare opcodes: 1000 = min, 1100 = max; fpExecutionType b10 = Compare (vfredusum/vfredosum are add)
+        val redFpCompare: Bool = maskPipeEnqReq.decodeResult(Decoder.fpExecutionType) === "b10".U
+        val redFpMin:     Bool = redFloat && redFpCompare && (redUop === "b1000".U)
+        val redFpMax:     Bool = redFloat && redFpCompare && (redUop === "b1100".U)
+        val dw = parameter.datapathWidth
+        def redIdElem(w: Int): UInt = {
+          val allOnes = ((BigInt(1) << w) - 1).U(w.W)
+          val sMax    = ((BigInt(1) << (w - 1)) - 1).U(w.W)
+          val sMin    = (BigInt(1) << (w - 1)).U(w.W)
+          val pInf    = (if (w == 32) BigInt("7f800000", 16) else if (w == 16) BigInt("7c00", 16) else BigInt(0)).U(w.W)
+          val nInf    = (if (w == 32) BigInt("ff800000", 16) else if (w == 16) BigInt("fc00", 16) else BigInt(0)).U(w.W)
+          Mux(
+            redFloat,
+            Mux(redFpMin, pInf, Mux(redFpMax, nInf, 0.U(w.W))),
+            Mux(
+              redIsMin,
+              Mux(redSign, sMax, allOnes),
+              Mux(redIsMax, Mux(redSign, sMin, 0.U(w.W)), Mux(redIsAnd, allOnes, 0.U(w.W)))
+            )
+          )
+        }
+        val redIdentityWord:   UInt = Mux1H(
+          enqSew,
+          Seq(Fill(dw / 8, redIdElem(8)), Fill(dw / 16, redIdElem(16)), Fill(dw / 32, redIdElem(32)))
+        )
+        val redElem0Mask:      UInt = enqBitMask.pad(dw)
         reduceResult := maskAnd(
           !enqIsPop,
-          maskReqQueue.deq.bits.maskPipe.source1 & enqBitMask
+          (maskReqQueue.deq.bits.maskPipe.source1 & redElem0Mask) | (redIdentityWord & (~redElem0Mask).asUInt)
         )
       }
       when(reduceStart) {


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

Every reduction whose identity element is not zero returns 0:

- `vredminu.vs` (unsigned min): 0 for all inputs
- `vredmin.vs` (signed min): 0 whenever the true minimum is positive
- `vredmax.vs` (signed max): 0 whenever every element is negative
- `vredand.vs`: 0 whenever the AND across the group has any bit clear
- `vfredmin.vs` / `vfredmax.vs`: 0 instead of the min / max

The reductions whose identity is zero (`vredsum`, `vredmaxu`, `vredor`, `vredxor`,
`vfredusum`, `vfredosum`) are correct. That split is the signature: a reduction folds
`acc = op(acc, elem)`, so the accumulator must start at the op's identity, but both
reduction stages seeded it to 0, which is only the add identity. The non-add reductions
then folded a phantom 0, and for min it dominated. Silent wrong result, no trap.

### Fix

Seed each accumulator to the operation's identity, computed from the decoded op, sign
and SEW and replicated per SEW-lane, at both stages:

- in-lane partial, `LaneExecutionBridge.scala` (`reduceResult`, fed back as ALU source 1)
- cross-lane combine, `MaskExchangeUnit.scala` (`reduceResult`, the daisy-chain fold)

| op class | identity |
|---|---|
| add / or / xor / unsigned max | `0` |
| unsigned min, `and` | all ones |
| signed min | max signed |
| signed max | min signed |
| float min / max | `+inf` / `-inf` |

`vfredusum`/`vfredosum` share the min uop encoding but are adds, so the float min/max
identity is gated on `fpExecutionType == Compare`; they stay byte-for-byte unchanged. An
init latch makes the integer seed land exactly once at the start of a reduction.