### PR TITLE
[test] add reduce_identity case reproducing non-zero-identity reductions

### DIFF
--- a/.github/designs/blastoise/t1emu.json
+++ b/.github/designs/blastoise/t1emu.json
@@ -9,5 +9,6 @@
   "asm.smoke": 11045,
   "intrinsic.conv2d_less_m2": 3040,
   "intrinsic.linear_normalization": 4934,
-  "intrinsic.softmax": 9186
+  "intrinsic.softmax": 9186,
+  "asm.reduce_identity": 1000
 }

--- a/.github/designs/blastoise/t1rocketemu.json
+++ b/.github/designs/blastoise/t1rocketemu.json
@@ -513,5 +513,6 @@
   "mlir.stripmining": 18655,
   "mlir.vectoradd": 15357,
   "pytorch.demo": 35250,
-  "pytorch.matmul": 75150
+  "pytorch.matmul": 75150,
+  "asm.reduce_identity": 1000
 }

--- a/.github/verilator/blastoise/t1emu.json
+++ b/.github/verilator/blastoise/t1emu.json
@@ -1,4 +1,5 @@
 {
   "mlir.matmul": 37595,
-  "intrinsic.conv2d_less_m2": 3041
+  "intrinsic.conv2d_less_m2": 3041,
+  "asm.reduce_identity": 1000
 }

--- a/.github/verilator/blastoise/t1rocketemu.json
+++ b/.github/verilator/blastoise/t1rocketemu.json
@@ -2,5 +2,6 @@
   "mlir.matmul": 58331,
   "intrinsic.conv2d_less_m2": 2961,
   "emurt-test.simple": 23001,
-  "disp.simple": 495535
+  "disp.simple": 495535,
+  "asm.reduce_identity": 1000
 }

--- a/tests/asm/reduce_identity/reduce_identity.S
+++ b/tests/asm/reduce_identity/reduce_identity.S
@@ -1,0 +1,59 @@
+# Reproduce: reduction accumulators must be seeded to the op identity, not 0.
+#
+# Every reduction below feeds an all-nonzero vs2 and a nonzero scalar vs1[0], so
+# the architecturally-correct result is nonzero. The buggy RTL seeds both the
+# in-lane accumulator and the cross-lane fold slots to 0; for ops whose identity
+# is not 0 (min / minu / and / signed max) that 0 gets folded in via op(x, 0) and
+# collapses the result. Difftest (RTL vs. spike) flags the mismatch; the results
+# are also parked in callee-saved GPRs so they are visible at exit.
+#
+#   op          vs2 (all)   vs1[0]   correct   buggy (seed 0)
+#   vredsum     5           0        80        80        <- control, 0 is identity, stays correct
+#   vredminu    0x05        0x7f     0x05      0x00      <- identity should be all-ones
+#   vredand     0xff        0xff     0xff      0x00      <- identity should be all-ones
+#   vredmin     0x05        0x7f     0x05      0x00      <- signed, identity should be smax(0x7f)
+#   vredmax     0xf0(=-16)  0xf0     0xf0      0x00      <- signed, identity should be smin(0x80)
+
+.global test
+test:
+    li   a0, 16                       # vl = 16 elements
+    vsetvli t0, a0, e8, m1, ta, ma
+
+    # --- control: vredsum, identity is 0, must stay correct on both master and branch
+    li   a1, 5
+    vmv.v.x v8, a1                     # vs2 = {5 x16}
+    vmv.s.x v16, x0                   # vs1[0] = 0
+    vredsum.vs v24, v8, v16
+    vmv.x.s s2, v24                    # expect 16*5 = 80 (0x50)
+
+    # --- vredminu: unsigned min, identity is all-ones
+    li   a1, 0x05
+    vmv.v.x v8, a1                     # vs2 = {0x05 x16}
+    li   a2, 0x7f
+    vmv.s.x v16, a2                   # vs1[0] = 0x7f
+    vredminu.vs v24, v8, v16
+    vmv.x.s s3, v24                    # expect 0x05 ; buggy -> 0x00
+
+    # --- vredand: bitwise and, identity is all-ones
+    li   a1, 0xff
+    vmv.v.x v8, a1                     # vs2 = {0xff x16}
+    vmv.s.x v16, a1                   # vs1[0] = 0xff
+    vredand.vs v24, v8, v16
+    vmv.x.s s4, v24                    # expect 0xff ; buggy -> 0x00
+
+    # --- vredmin: signed min, identity is smax (0x7f for e8)
+    li   a1, 0x05
+    vmv.v.x v8, a1                     # vs2 = {+5 x16}
+    li   a2, 0x7f
+    vmv.s.x v16, a2                   # vs1[0] = +127
+    vredmin.vs v24, v8, v16
+    vmv.x.s s5, v24                    # expect 0x05 ; buggy -> 0x00
+
+    # --- vredmax: signed max, identity is smin (0x80 for e8)
+    li   a1, 0xf0                      # -16 in two's complement e8
+    vmv.v.x v8, a1                     # vs2 = {-16 x16}
+    vmv.s.x v16, a1                   # vs1[0] = -16
+    vredmax.vs v24, v8, v16
+    vmv.x.s s6, v24                    # expect 0xf0 (-16) ; buggy -> 0x00
+
+    ret


### PR DESCRIPTION
新增 asm 用例 `asm.reduce_identity`，复现规约累加器被初始化为 0 而非运算
identity 的 bug。用例对 `vredminu` / `vredand` / `vredmin` / `vredmax` 喂
全非零输入且标量 vs1[0] 非零，正确结果非零；buggy RTL 在 lane 内累加与跨
lane 折叠两级都把空槽 seed 成 0，`op(x, 0)` 把结果塌成 0。对照项 `vredsum`
（identity 恰为 0）保持正确。

同时把该用例注册进四条 CI 清单（vcs 的 .github/designs 与 verilator 的
.github/verilator，各 t1emu / t1rocketemu），difftest 与 spike 比对不一致会
让 CI job 失败，从而在 master 上暴露此 bug。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014eRRG8w8mRhCBTGrS4iqsi
