### PR TITLE
[rtl] Fix divide after a sqrt or float op using stale op-type flags

### DIFF
--- a/t1/src/LaneDivFP.scala
+++ b/t1/src/LaneDivFP.scala
@@ -304,7 +304,8 @@ class SRTFPWrapper(expWidth: Int, sigWidth: Int) extends Module {
   val sqrtMuxIn     = Wire(new IterMuxIO(expWidth, sigWidth, fpWidth, ohWidth, iterWidth))
   val divMuxIn      = Wire(new IterMuxIO(expWidth, sigWidth, fpWidth, ohWidth, iterWidth))
   val divSqrtMuxOut = Wire(new IterMuxIO(expWidth, sigWidth, fpWidth, ohWidth, iterWidth))
-  divSqrtMuxOut := Mux(opSqrtReg || (input.bits.opSqrt && input.fire), sqrtMuxIn, divMuxIn)
+  // The arriving request selects on a fire, opSqrtReg only holds the in-flight op
+  divSqrtMuxOut := Mux(Mux(input.fire, input.bits.opSqrt, opSqrtReg), sqrtMuxIn, divMuxIn)
 
   val divValid  = input.valid && !bypassInteger && !bypassFloat && !opSqrt
   val sqrtValid = input.valid && input.bits.opSqrt && normalCaseSqrt
@@ -332,7 +333,8 @@ class SRTFPWrapper(expWidth: Int, sigWidth: Int) extends Module {
   divIter.input.bits.partialSum   := partialSum
   divIter.input.bits.partialCarry := partialCarry
   divIter.input.bits.divider      := divDivisor
-  divIter.input.bits.counter      := Mux(opFloatReg || (opFloat && input.fire), 8.U, counter)
+  // Same stale flag, opFloatReg still holds the previous op until the next fire
+  divIter.input.bits.counter      := Mux(Mux(input.fire, opFloat, opFloatReg), 8.U, counter)
 
   sqrtIter.respOTF.quotient         := otf(0)
   sqrtIter.respOTF.quotientMinusOne := otf(1)


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

A divide returns a wrong quotient when it follows a square root or any float op. It affects `vdiv`,
`vdivu`, `vrem`, `vremu` and `vfdiv`. The divide is correct on its own, no trap is raised, and
spacing the two instructions apart does not help.

`SRTFPWrapper` in `t1/src/LaneDivFP.scala` runs integer divide, float divide and square root on one
shared SRT datapath, steered by two registers:

```scala
val opFloatReg = RegEnable(opFloat,           false.B, input.fire)
val opSqrtReg  = RegEnable(input.bits.opSqrt, false.B, input.fire)
```

Both are enabled by `input.fire` and never cleared, so after an op retires they still read its type
until the next request fires. Two sites OR one of them with the incoming request as
`X || (incoming && input.fire)`, which is wrong in the one case where the arriving request is not X
but the stale register still says X. `input.ready` is `divReady && sqrtReady`, so that case only
means a different op is arriving after the previous one finished. A divide after a sqrt then seeds
the shared `partialSum` with the sqrt's init instead of the dividend. A divide after a float op
takes the float's fixed 8 iterations instead of the leading-zero derived `counter` and returns an
unnormalised quotient. `vfsqrt` is both and hits both paths.

### Fix

Select on the arriving request when input fires, and on the registered flag only between fires:

```scala
divSqrtMuxOut := Mux(Mux(input.fire, input.bits.opSqrt, opSqrtReg), sqrtMuxIn, divMuxIn)
divIter.input.bits.counter := Mux(Mux(input.fire, opFloat, opFloatReg), 8.U, counter)
```

Each expression matches the old one wherever it was already right. Both lines are needed, the
div/sqrt select and the iteration count are separate.

Checked on `blastoise` against spike. `vfsqrt.v` then a self `vdivu.vv` gives 1 for every element
with the patch and garbage without, at 0, 1, 2, 4 and 8 `nop` gaps alike. Of 63 failing random
programs 61 pass with the patch, each first flagged on a divide or a remainder. The other 2 fail on
an unrelated scalar `flw`.
